### PR TITLE
`danube_ienc` - Render title in relevant catalog's

### DIFF
--- a/danube_ienc.sh
+++ b/danube_ienc.sh
@@ -24,7 +24,7 @@ function process_country() {
 
   WORKDIR='/tmp'
   if curl -f -o "${WORKDIR}/danube_ienc.html" "$URL"; then
-    ./danube_ienc.py ${WORKDIR}/danube_ienc.html "" > ${WORKDIR}/${CATALOGNAME}
+    ./danube_ienc.py ${WORKDIR}/danube_ienc.html "${TITLE}" > ${WORKDIR}/${CATALOGNAME}
     if xmllint --noout ${WORKDIR}/${CATALOGNAME} 2>&1 >/dev/null; then
       cat ${WORKDIR}/${CATALOGNAME} | xmllint --format - >  ${TARGETDIR}/${CATALOGNAME}
       rm ${WORKDIR}/${CATALOGNAME}


### PR DESCRIPTION
Fixes #8

This change passes the title specified in `danube_ienc.sh` into `danube_ienc.py` (rather than a blank string).

This can be seen by comparing the generated files with and without this change;

```
$ for x in old/*.xml; do name=$(basename $x); echo -e "$name:\n  old: $(xq -x '//Header/title' old/$name)\n  new: $(xq -x '//Header/title' new/$name)"; done
BG_IENC_Catalog.xml:
  old:
  new: Bulgaria IENC Charts
HR_IENC_Catalog.xml:
  old:
  new: Croatia IENC Charts
HU_IENC_Catalog.xml:
  old:
  new: Hungary IENC Charts
RO_IENC_Catalog.xml:
  old:
  new: Romania IENC Charts
RS_IENC_Catalog.xml:
  old:
  new: Serbia IENC Charts
SK_IENC_Catalog.xml:
  old:
  new: Slovakia IENC Charts
```

This will hopefully then be reflected within the OpenCPN interface, providing a more user friendly list.